### PR TITLE
release-schema: add lot object to release schema, update examples in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension adds a field to indicate the international legal instruments that the contracting process is covered by.
 
-For example, the Agreement on Government Procurement (GPA) is a treaty that requires members to indicate whether a contracting process is covered by it. The European Union's Clean Vehicles Directive is a legal act that provides for member states to indicate associated information in procurement notices. The `coveredBy` field should be used to meet such requirements.
+For example, the Agreement on Government Procurement (GPA) is a treaty that requires members to indicate whether a contracting process is covered by it. The Clean Vehicles Directive is a legal act that provides for member states of the European Union to indicate associated information in procurement notices. The `coveredBy` field should be used to meet such requirements.
 
 To disclose the laws or regulations that govern the contracting process and that grant legal authority to the procuring entity, use the [legalBasis extension](https://github.com/open-contracting-extensions/ocds_legalBasis_extension) instead.
 
@@ -67,7 +67,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2023-03-02
 
-* Add "EU-CVD" to the `coveredBy` codelist.
+* Add 'EU-CVD' to the `coveredBy` codelist.
 * Add `coveredBy` to the `Lot` object.
 
 ### 2020-11-04

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension adds a field to indicate the treaties or directives that the contracting process is covered by.
 
-A treaty, like the Agreement on Government Procurement (GPA), can require a member to indicate that a contracting process is covered by it. The `coveredBy` field should be used to meet such requirements.
+A treaty, like the Agreement on Government Procurement (GPA), can require a member to indicate that a contracting process is covered by it. Similarly, a legislative standard for publishing procurement data, like [eForms](https://single-market-economy.ec.europa.eu/single-market/public-procurement/digital-procurement/eforms_en) in the European Union, can allow contracting authorities to indicate that a lot is covered by a directive, like the [Clean Vehicles Directive](https://transport.ec.europa.eu/transport-themes/clean-transport-urban-transport/clean-and-energy-efficient-vehicles/clean-vehicles-directive_en). The `coveredBy` field should be used to meet such requirements.
 
 To disclose the laws or regulations that govern the contracting process and that grant legal authority to the procuring entity, use the [legalBasis extension](https://github.com/open-contracting-extensions/ocds_legalBasis_extension) instead.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Covered By
 
-This extension adds a field to indicate the treaties that the contracting process is covered by.
+This extension adds a field to indicate the treaties or directives that the contracting process is covered by.
 
-A treaty, like the Agreement on Government Procurement (GPA), can require a member to indicate that a contracting process is covered by it. The `tender.coveredBy` field should be used to meet such requirements.
+A treaty, like the Agreement on Government Procurement (GPA), can require a member to indicate that a contracting process is covered by it. The `coveredBy` field should be used to meet such requirements.
 
 To disclose the laws or regulations that govern the contracting process and that grant legal authority to the procuring entity, use the [legalBasis extension](https://github.com/open-contracting-extensions/ocds_legalBasis_extension) instead.
+
+If you are using the [Lots extension](https://extensions.open-contracting.org/en/extensions/lots/master/), [follow its guidance](https://extensions.open-contracting.org/en/extensions/lots/master/#usage) on whether to use `tender.lots` fields or `tender` fields.
 
 ## Guidance
 
@@ -13,7 +15,7 @@ If you need to refer to a treaty that is not in the `coveredBy` codelist:
 1. If the treaty has a national or subnational scope, pick a relevant [ISO 3166-1 alpha-2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) (e.g "CA" for Canada).
 1. If the treaty has a subnational scope, pick a relevant [ISO 3166-2 region code](https://en.wikipedia.org/wiki/ISO_3166-2) (e.g "NT" for [Northern Territories](https://en.wikipedia.org/wiki/ISO_3166-2:CA#Current_codes), a province of Canada).
 1. Concatenate the code(s) to the acronym of the treaty, separating each part with a dash (e.g "CA-NT-BIP").
-1. Add this code to the `tender.coveredBy` array.
+1. Add this code to the `coveredBy` array.
 1. Document the new code (see [Extending open codelists](https://standard.open-contracting.org/latest/en/schema/codelists/)).
 
 ## Legal context
@@ -22,9 +24,13 @@ The [Revised Agreement on Government Procurement](https://www.wto.org/english/do
 
 The European Union is a [party](https://www.wto.org/english/tratop_e/gproc_e/memobs_e.htm) to the GPA, and as such its [Directive 2014/24/EU](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2014.094.01.0065.01.ENG) (Public contracts — setting out clear ground rules) includes: "Part C: Information to be included in contract notices … 29. Indication whether the contract is covered by the GPA."
 
+In the European Union, this extension's fields correspond to [eForms BT-115 (GPA Coverage) and BT-717 (Clean Vehicles Directive)](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/). See [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/latest/en/) for the correspondences to eForms fields.
+
 ## Example
 
-The `tender.coveredBy` field is an array of strings, whose values are selected from the `coveredBy.csv` open codelist.
+The `coveredBy` field is an array of strings, whose values are selected from the `coveredBy.csv` open codelist.
+
+### Tender
 
 ```json
 {
@@ -36,11 +42,33 @@ The `tender.coveredBy` field is an array of strings, whose values are selected f
 }
 ```
 
+### Lot
+
+```json
+{
+  "tender": {
+    "lots": [
+      {
+        "id": "LOT-0001",
+        "coveredBy": [
+          "EU-CVD"
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## Issues
 
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2023-03-02
+
+* Add "EU-CVD" to the `coveredBy` codelist.
+* Add `coveredBy` to the `Lot` object.
 
 ### 2020-11-04
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Covered By
 
-This extension adds a field to indicate the treaties or directives that the contracting process is covered by.
+This extension adds a field to indicate the international legal instruments that the contracting process is covered by.
 
-A treaty, like the Agreement on Government Procurement (GPA), can require a member to indicate that a contracting process is covered by it. Similarly, a legislative standard for publishing procurement data, like [eForms](https://single-market-economy.ec.europa.eu/single-market/public-procurement/digital-procurement/eforms_en) in the European Union, can allow contracting authorities to indicate that a lot is covered by a directive, like the [Clean Vehicles Directive](https://transport.ec.europa.eu/transport-themes/clean-transport-urban-transport/clean-and-energy-efficient-vehicles/clean-vehicles-directive_en). The `coveredBy` field should be used to meet such requirements.
+For example, the Agreement on Government Procurement (GPA) is a treaty that requires members to indicate whether a contracting process is covered by it. The European Union's Clean Vehicles Directive is a legal act that provides for member states to indicate associated information in procurement notices. The `coveredBy` field should be used to meet such requirements.
 
 To disclose the laws or regulations that govern the contracting process and that grant legal authority to the procuring entity, use the [legalBasis extension](https://github.com/open-contracting-extensions/ocds_legalBasis_extension) instead.
 

--- a/codelists/coveredBy.csv
+++ b/codelists/coveredBy.csv
@@ -1,2 +1,3 @@
 Code,Title
 GPA,Agreement on Government Procurement
+EU-CVD,European Parliament and Council 2009/33/EC (Clean Vehicles Directive)

--- a/extension.json
+++ b/extension.json
@@ -20,5 +20,8 @@
   "contactPoint": {
     "name": "Open Contracting Partnership",
     "email": "data@open-contracting.org"
-  }
+  },
+  "testDependencies": [
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+  ]
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -24,7 +24,7 @@
       "properties": {
         "coveredBy": {
           "title": "Covered by",
-          "description": "The treaties and directives that the contracting process for this lot is covered by.",
+          "description": "The treaties and directives that the lot is covered by.",
           "type": [
             "array",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,7 +4,7 @@
       "properties": {
         "coveredBy": {
           "title": "Covered by",
-          "description": "The treaties and directives that the contracting process is covered by.",
+          "description": "The international legal instruments that the contracting process is covered by.",
           "type": [
             "array",
             "null"
@@ -24,7 +24,7 @@
       "properties": {
         "coveredBy": {
           "title": "Covered by",
-          "description": "The treaties and directives that the lot is covered by.",
+          "description": "The international legal instruments that the lot is covered by.",
           "type": [
             "array",
             "null"

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,7 +4,27 @@
       "properties": {
         "coveredBy": {
           "title": "Covered by",
-          "description": "The treaties that the contracting process is covered by.",
+          "description": "The treaties and directives that the contracting process is covered by.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "codelist": "coveredBy.csv",
+          "openCodelist": true,
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      }
+    },
+    "Lot": {
+      "properties": {
+        "coveredBy": {
+          "title": "Covered by",
+          "description": "The treaties and directives that the contracting process for this lot is covered by.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
…README.md, add code to codelist

Hopefully another straightforward update to account for eforms requirements. I've altered the description slightly to refer to "treaties and directives" as we're adding EU-Clean Vehicles Directive to this as it fit the semantics of this extension but not the semantics of the legal basis extension.

The codelist test is failing, I think because it's objecting to the presence of a - in the code, but this code style is following the guidance in this extension so I've ignored it for now.